### PR TITLE
@index is never used in the code so remove it

### DIFF
--- a/lib/mailbox.rb
+++ b/lib/mailbox.rb
@@ -26,7 +26,6 @@ class Mailbox
     fail ReportError.new self, msg: 'Mailbox expire must be greater than or equal to Message expire' if @tmout_msg > @tmout_mbx
 
     @hpk = b64enc hpk
-    @index = {}
     @lastCount = nil
   end
 


### PR DESCRIPTION

Looks like this line of code which declares @index is never used....
Ran all of the tests on zax and glow and they pass.
