### PR TITLE
Loosen the requirement to Ruby(`~> 2.4.1`)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.4.1"
+ruby "~> 2.4.1"
 
 gem 'rails', '5.1.3'
 


### PR DESCRIPTION
Without this, `bundle install` fails on `2.4.4`,

```
➜  zax git:(less-strict-ruby-version-requirement) bundle install
Your Ruby version is 2.4.4, but your Gemfile specified 2.4.1
```

which is [the latest minor version](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/) of `2.4`.