### PR TITLE
Fix production boot: pin connection_pool < 3, bump puma to 7.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 7.2', '>= 7.2.3.1'
 
-gem 'puma'
+gem 'puma', '~> 7.2'
 # gem "sprockets-rails"
 
 group :development, :test do
@@ -15,6 +15,10 @@ gem 'kgio'
 
 gem 'redis'
 gem 'redis-rails'
+
+# activesupport 7.2's :redis_cache_store is incompatible with connection_pool 3.x
+# (ConnectionPool.new signature change -> ArgumentError on boot). Hold at 2.x.
+gem 'connection_pool', '< 3'
 
 gem 'rbnacl'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     cgi (0.5.1)
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     date (3.5.1)
     drb (2.2.3)
@@ -145,7 +145,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (6.4.3)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
@@ -238,11 +238,12 @@ PLATFORMS
 
 DEPENDENCIES
   base32
+  connection_pool (< 3)
   kgio
   minitest-reporters
   mutex_m (~> 0.3.0)
   pry (~> 0.14.2)
-  puma
+  puma (~> 7.2)
   rails (~> 7.2, >= 7.2.3.1)
   rbnacl
   redis


### PR DESCRIPTION
## Summary

The app currently **does not boot in production** on `main`, independent of any pending dependabot PR. This fixes that and folds in the verified puma 7 upgrade.

### 1. Production boot blocker — `connection_pool` 3.x (urgent)

`connection_pool` 3.0.2 changed the `ConnectionPool.new` signature, which is incompatible with `activesupport` 7.2's `:redis_cache_store` (set globally in `config/application.rb`). Production boot fails with:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
connection_pool-3.0.2/lib/connection_pool.rb:48:in 'initialize'
```

CI stays green because `config/environments/test.rb` overrides `cache_store` to `:memory_store`, so the broken path is never exercised by the test suite. Pin `connection_pool < 3` (resolves to **2.5.5**) to restore production boot.

### 2. Puma 6.4.3 → 7.2.1 (folds in the pending dependabot bump)

The major bump was verified safe for this Rack-2.2 / unix-socket / clustered config:

- Every Puma 7 breaking change is either **Rack-3-gated** (inert under the hard `rack 2.2.23` pin) or a **no-op** given `config/puma.rb` (`preload_app!` already set; `on_worker_boot` kept as a working alias — emits only a deprecation warning; block body is empty).
- 7.2.1 fixes two **High-severity PROXY-protocol CVEs** (CVE-2026-47736, CVE-2026-47737) present in 6.4.3 — inert here since `proxy_protocol :v1` is never enabled, but a defense-in-depth win and the supported patch path (6.x is unmaintained).
- Pins `puma ~> 7.2` so an unconstrained `bundle update` can't jump to the untested **8.x** major.

`nio4r` (2.7.5) and `rack` (2.2.23) are unchanged.

## Verification

- ✅ Production boots: `puma=7.2.1 cp=2.5.5`
- ✅ Cluster-mode boot with `config/puma.rb` binds the unix socket and serves a real Rails response over it (HTTP 404 routing); only log line is the expected `on_worker_boot` deprecation warning
- ✅ Test suite: **36 tests, 1313 assertions, 0 failures, 0 errors, 0 skips**

## Follow-up (not in this PR)

Optionally rename `on_worker_boot` → `before_worker_boot` in `config/puma.rb` (or delete the empty block) to silence the deprecation warning and stay Puma-8-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)